### PR TITLE
Updating bucket creation

### DIFF
--- a/modules/loki/bucket.tf
+++ b/modules/loki/bucket.tf
@@ -17,10 +17,8 @@ module "loki_log" {
   version = "3.10.1"
 
   bucket                  = format("%s-log", local.service_name)
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
 
   acl           = "log-delivery-write"
   force_destroy = true
@@ -51,10 +49,8 @@ module "loki" {
   version = "3.10.1"
 
   bucket                  = local.service_name
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
 
   acl           = "private"
   force_destroy = true

--- a/modules/mimir/bucket.tf
+++ b/modules/mimir/bucket.tf
@@ -17,10 +17,8 @@ module "mimir_log" {
   version = "3.10.1"
 
   bucket                  = format("%s-log", local.service_name)
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
 
   acl           = "log-delivery-write"
   force_destroy = true
@@ -51,10 +49,8 @@ module "mimir" {
   version = "3.10.1"
 
   bucket                  = local.service_name
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
 
   acl           = "private"
   force_destroy = true

--- a/modules/tempo/bucket.tf
+++ b/modules/tempo/bucket.tf
@@ -17,10 +17,8 @@ module "tempo_log" {
   version = "3.10.1"
 
   bucket                  = format("%s-log", local.service_name)
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
 
   acl           = "log-delivery-write"
   force_destroy = true
@@ -51,10 +49,8 @@ module "tempo" {
   version = "3.10.1"
 
   bucket                  = local.service_name
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
 
   acl           = "private"
   force_destroy = true

--- a/modules/thanos/bucket.tf
+++ b/modules/thanos/bucket.tf
@@ -17,11 +17,10 @@ module "thanos_log" {
   version = "3.10.1"
 
   bucket                  = format("%s-log", local.service_name)
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
 
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
+  
   acl           = "log-delivery-write"
   force_destroy = true
 
@@ -51,10 +50,9 @@ module "thanos" {
   version = "3.10.1"
 
   bucket                  = local.service_name
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
 
   acl           = "private"
   force_destroy = true


### PR DESCRIPTION
AWS changed the their ACL to default to disabled and block public access, therefore you cannot create buckets the old way.

This will re enable the creation of buckets and set the objects ownership.